### PR TITLE
For pattern-exact-fa, construct DFAs that exact less than r mismatches and add exact matches as matching transitions

### DIFF
--- a/src/makerep-pattern-exact-fa.cpp
+++ b/src/makerep-pattern-exact-fa.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <vector>
-#include <cstdlib> 
+#include <cstdlib>
 
 #include "dfa.hpp"
 #include "aminoacids.hpp"
@@ -30,12 +30,12 @@ DFA<N_AMINOACIDS+1> branch( int n, int r ){
 				R.addEdge( row+i, row+i+n-l, N_AMINOACIDS, Vcode );
 			}
 		}
-		if(  l < n && l == r ){
+		if(  l < n && l <= r ){
 			for( int k = 0 ; k < N_AMINOACIDS ; k ++ ){
 				R.addEdge( row+n-l-1, acc, c2i(aminoacids[k]), Vcode );
 			}
 		}
-		if(  l < n && l == r-1 ){
+		if(  l < n && l < r ){
 			R.addEdge( row+n-l-1, acc, N_AMINOACIDS, Vcode );
 		}
 		row += n-l;
@@ -53,7 +53,7 @@ int main( int argc, char * argv[] )
 		cerr << "Usage : " << argv[0] << " [n] [r] " << endl;
 		exit(1);
 	}
-	int n = atoi( argv[1] ), r = atoi( argv[2] ); 
+	int n = atoi( argv[1] ), r = atoi( argv[2] );
 	DFA<N_AMINOACIDS+1> A = branch( n, r );
 	A = A.minimize();
 	A.print();

--- a/src/pattern-exact-fa.cpp
+++ b/src/pattern-exact-fa.cpp
@@ -15,8 +15,7 @@ inline int c2i( int c ){
 void add_match_edge( DFA<N_AMINOACIDS+1> & R , int s1, int s2, int c,
 	map<long,long> & Vcode ){
 	for( int k = 0 ; k < N_AMINOACIDS ; k ++ ){
-		if( (aminoacids[k] != c) &&
-			pmbec_subst[aminoacids[k]-'A'][c-'A'] ){
+		if( pmbec_subst[aminoacids[k]-'A'][c-'A'] ){
 				R.addEdge( s1, s2, c2i(aminoacids[k]), Vcode );
 		}
 	}
@@ -33,9 +32,7 @@ DFA<N_AMINOACIDS+1> branch_for_peptide( string pep, int n, int r ){
 	R.addState( 0, Vcode );
 	for( l = 0 ; l <= r && l <= n ; l ++ ){
 		for( i = 0 ; i < n-l-1 ; i ++ ){
-			// uncomment line below for fuzzy match
 			add_match_edge( R, row+i, row+i+1, pep[i+l], Vcode );
-			//R.addEdge( row+i, row+i+1, c2i(pep[i+l]), Vcode );
 			//cerr << row+i << "\t" << row+i+1 << "\t" << pep[i+l] << endl;
 			if( l < r ){
 				R.addEdge( row+i, row+i+n-l, N_AMINOACIDS, Vcode );
@@ -43,9 +40,7 @@ DFA<N_AMINOACIDS+1> branch_for_peptide( string pep, int n, int r ){
 			}
 		}
 		if(  l < n && l <= r ){
-			// uncomment line below for fuzzy match
 			add_match_edge( R, row+n-l-1, acc, pep[n-1], Vcode );
-			//R.addEdge( row+n-l-1, acc, c2i(pep[n-1]), Vcode );
 			//cerr << row+i << "\t" << acc << "\t" << pep[n-1] << "\n";
 		}
 		if(  l < n && l < r ){

--- a/src/pattern-exact-fa.cpp
+++ b/src/pattern-exact-fa.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <vector>
-#include <cstdlib> 
+#include <cstdlib>
 
 #include "dfa.hpp"
 #include "aminoacids.hpp"
@@ -12,10 +12,10 @@ inline int c2i( int c ){
 	return aa_goedel[c-'A'];
 }
 
-void add_match_edge( DFA<N_AMINOACIDS+1> & R , int s1, int s2, int c, 
+void add_match_edge( DFA<N_AMINOACIDS+1> & R , int s1, int s2, int c,
 	map<long,long> & Vcode ){
 	for( int k = 0 ; k < N_AMINOACIDS ; k ++ ){
-		if( (aminoacids[k] != c) && 
+		if( (aminoacids[k] != c) &&
 			pmbec_subst[aminoacids[k]-'A'][c-'A'] ){
 				R.addEdge( s1, s2, c2i(aminoacids[k]), Vcode );
 		}
@@ -42,13 +42,13 @@ DFA<N_AMINOACIDS+1> branch_for_peptide( string pep, int n, int r ){
 				//cerr << row+i << "\t" << row+i+n-l << "\t#\n";
 			}
 		}
-		if(  l < n && l == r ){
+		if(  l < n && l <= r ){
 			// uncomment line below for fuzzy match
 			add_match_edge( R, row+n-l-1, acc, pep[n-1], Vcode );
 			//R.addEdge( row+n-l-1, acc, c2i(pep[n-1]), Vcode );
 			//cerr << row+i << "\t" << acc << "\t" << pep[n-1] << "\n";
 		}
-		if(  l < n && l == r-1 ){
+		if(  l < n && l < r ){
 			R.addEdge( row+n-l-1, acc, N_AMINOACIDS, Vcode );
 			//cerr << row+i << "\t" << acc << "\t#\n";
 		}
@@ -78,7 +78,7 @@ int main( int argc, char * argv[] )
 		cerr << "Usage : " << argv[0] << " [n] [r] " << endl;
 		exit(1);
 	}
-	int n = atoi( argv[1] ), r = atoi( argv[2] ); 
+	int n = atoi( argv[1] ), r = atoi( argv[2] );
 	long current_node = 2;
 	string line;
 	DFA<N_AMINOACIDS+1> A;
@@ -87,10 +87,10 @@ int main( int argc, char * argv[] )
 		getline( cin, line );
 		if( line.length() >= n ){
 			pep = line.substr( 0, n );
-			As.push_back( branch_for_peptide( pep, n, r ) ); 
+			As.push_back( branch_for_peptide( pep, n, r ) );
 		}
 	}
-	
+
 	while( As.size() > 1 ){
 		As = fold( As );
 	}


### PR DESCRIPTION
There are two commits to this PR, both fixes to apparent bugs in the construction of DFAs.

The first commit changes what states are connected to the connecting state. The figure below shows the DFA that is constructed by the original code for matching the peptide "abc" with r=2. Edges are labeled "a", "b", "c" to mean any aminoacid matching these positions and they are labeled "#" to indicate a mismatch. Numbers between parentheses indicate which line of code generated the edge corresponding to the label.

![pattern_exact_orig](https://user-images.githubusercontent.com/24913595/125943486-ce96e04e-3172-4088-806b-9e6e5026c4fe.png)

As can be seen, only the final row is connected to the accepting state. The resulting DFA accepts only strings containing /exactly/ r "#" characters.

The DFA that is constructed by the new code for the same purpose looks like so:

![pattern_exact_new](https://user-images.githubusercontent.com/24913595/125943498-b909f4ea-7914-4789-8785-7b7b49c32205.png)

This DFA accepts strings containing r or less than r "#" characters.

The second commit fixes a perceived error with failing to insert matching state transitions for exact matches. One function explicitly tests against adding exact matches in, while the other comments out the line of code that would add these in. The commit deletes the comments and the test, so that exact matches are added as matching state transitions.